### PR TITLE
Removed branch specifier from terriajs dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "less-plugin-npm-import": "^2.1.0",
     "node-notifier": "^4.5.0",
     "raw-loader": "^0.5.1",
-    "terriajs": "git://github.com/TerriaJS/terriajs.git#webpack",
+    "terriajs": "git://github.com/TerriaJS/terriajs.git",
     "terriajs-catalog-editor": "^0.2.0",
     "terriajs-cesium": "1.19.2",
     "terriajs-schema": "latest",


### PR DESCRIPTION
Resolves #9 -- the webpack branch was merged into master, so this is the minimal fix.

It's possible, depending on how you're running the project, that depending on terriajs/master is more risky, but it looks to me like master is generally stable.