### PR TITLE
Update to add a configuration parameter to specify the default mobile view mode.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+### 2017-XX-XX
+
+* Change deafult mobile view mode to a configuration parameter rather then hard coded to 2D.
+
 ### 2016-11-15
 
 * Fixed link to NEII viewer in Related Maps.

--- a/index.js
+++ b/index.js
@@ -17,7 +17,6 @@ var configuration = {
 // checkBrowserCompatibility('ui');
 import GoogleAnalytics from 'terriajs/lib/Core/GoogleAnalytics';
 import ShareDataService from 'terriajs/lib/Models/ShareDataService';
-import isCommonMobilePlatform from 'terriajs/lib/Core/isCommonMobilePlatform';
 import OgrCatalogItem from 'terriajs/lib/Models/OgrCatalogItem';
 import raiseErrorToUser from 'terriajs/lib/Models/raiseErrorToUser';
 import registerAnalytics from 'terriajs/lib/Models/registerAnalytics';
@@ -73,7 +72,6 @@ terria.start({
     // as well as the call to "updateApplicationOnHashChange" further down.
     applicationUrl: window.location,
     configUrl: 'config.json',
-    defaultTo2D: isCommonMobilePlatform(),
     shareDataService: new ShareDataService({
         terria: terria
     })

--- a/wwwroot/config.json
+++ b/wwwroot/config.json
@@ -53,7 +53,11 @@
         // You probably shouldn't change this.
         proj4ServiceBaseUrl: "proj4def/",
         // Or this
-        feedbackUrl: "feedback"
+        feedbackUrl: "feedback",
+
+        // Default mobile viewer mode when loading the map for the first time on mobile platforms.
+        // Options are: "3DTerrain", "3DSmooth", "2D"
+        mobileDefaultViewerMode: "2d",
     }
 }
 


### PR DESCRIPTION
I have updated terriajs to allow the default view mode when the device is a mobile browser to be specified from the configuration file. This PR changes the TerriaMap behavior so that it now relies on the configuration parameter to set the default view mode when running on a mobile platform.