### PR TITLE
Use `gtar` when building `make-package` on OSX to create GNU tar comp…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@ Change Log
 
 ### 2017-XX-XX
 
+* Use `gtar` when building `make-package` on OSX to create GNU tar compatible tarballs.
 * Change deafult mobile view mode to a configuration parameter rather then hard coded to 2D.
 * Add Augmented Reality mode for iOS and Android devices with a compass and accelerometer, activated by enabling `experimentalFeatures` in `config.json` and adding the AugmentedVirtualityTool to the ExperimentalMenu in the customisable user interface.
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -177,7 +177,11 @@ gulp.task('make-package', function() {
         fs.writeFileSync(path.join(workingDir, 'wwwroot', 'config.json'), JSON.stringify(productionClientConfig, undefined, '  '));
     }
 
-    var tarResult = spawnSync('tar', [
+    // if we are on OSX make sure to use gtar for compatibility with Linux
+    // otherwise we see lots of error message when extracting with GNU tar
+    var tar = /^darwin/.test(process.platform) ? 'gtar' : 'tar';
+
+    var tarResult = spawnSync(tar, [
         'czf',
         path.join('..', 'packages', packageName + '.tar.gz')
     ].concat(fs.readdirSync(workingDir)), {
@@ -315,7 +319,7 @@ function checkForDuplicateCesium() {
         console.log('You have two copies of terriajs-cesium, one in this application\'s node_modules\n' +
                     'directory and the other in node_modules/terriajs/node_modules/terriajs-cesium.\n' +
                     'This leads to strange problems, such as knockout observables not working.\n' +
-                    'Please verify that node_modules/terriajs-cesium is the correct version and\n' + 
+                    'Please verify that node_modules/terriajs-cesium is the correct version and\n' +
                     '  rm -rf node_modules/terriajs/node_modules/terriajs-cesium\n' +
                     'Also consider running:\n' +
                     '  npm run gulp sync-terriajs-dependencies\n' +


### PR DESCRIPTION
…atible tarballs.