### PR TITLE
Deployment tweaks

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -156,13 +156,9 @@ gulp.task('make-package', function(done) {
 
     fs.mkdirSync(workingDir);
 
-    var copyOptions = {
-        preserveTimestamps: true
-    };
-
-    fs.copySync('wwwroot', path.join(workingDir, 'wwwroot'), copyOptions);
-    fs.copySync('node_modules', path.join(workingDir, 'node_modules'), copyOptions);
-    fs.copySync('deploy/varnish', path.join(workingDir, 'varnish'), copyOptions);
+    fs.copySync('wwwroot', path.join(workingDir, 'wwwroot'));
+    fs.copySync('node_modules', path.join(workingDir, 'node_modules'));
+    fs.copySync('deploy/varnish', path.join(workingDir, 'varnish'));
 
     if (argv.serverConfigOverride) {
         var serverConfig = json5.parse(fs.readFileSync('devserverconfig.json', 'utf8'));

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "gulp": "gulp",
     "postinstall": "echo 'Installation successful. What to do next:\\n  npm start       # Starts the server on port 3001\\n  gulp watch      # Builds TerriaMap and dependencies, and rebuilds if files change.'",
     "hot": "webpack-dev-server --inline --config buildprocess/webpack.config.hot.js --hot --host 0.0.0.0",
-    "deploy": "rm -rf node_modules && npm install --no-package-lock && npm run deploy-without-reinstall",
+    "deploy": "aws --profile terria s3 ls && rm -rf node_modules && npm install --no-package-lock && npm run deploy-without-reinstall",
     "deploy-without-reinstall": "gulp clean && gulp release && npm run deploy-current",
     "deploy-current": "npm run get-deploy-overrides && gulp make-package --serverConfigOverride ./privateserverconfig.json --clientConfigOverride ./wwwroot/privateconfig.json && cd deploy/aws && ./stack create && cd ../..",
     "get-deploy-overrides": "aws s3 --profile $npm_package_config_awsProfile cp $npm_package_config_awsS3ServerConfigOverridePath ./privateserverconfig.json && aws s3 --profile $npm_package_config_awsProfile cp $npm_package_config_awsS3ClientConfigOverridePath ./wwwroot/privateconfig.json"

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "gulp": "gulp",
     "postinstall": "echo 'Installation successful. What to do next:\\n  npm start       # Starts the server on port 3001\\n  gulp watch      # Builds TerriaMap and dependencies, and rebuilds if files change.'",
     "hot": "webpack-dev-server --inline --config buildprocess/webpack.config.hot.js --hot --host 0.0.0.0",
-    "deploy": "rm -rf node_modules && npm install && npm run deploy-without-reinstall",
+    "deploy": "rm -rf node_modules && npm install --no-package-lock && npm run deploy-without-reinstall",
     "deploy-without-reinstall": "gulp clean && gulp release && npm run deploy-current",
     "deploy-current": "npm run get-deploy-overrides && gulp make-package --serverConfigOverride ./privateserverconfig.json --clientConfigOverride ./wwwroot/privateconfig.json && cd deploy/aws && ./stack create && cd ../..",
     "get-deploy-overrides": "aws s3 --profile $npm_package_config_awsProfile cp $npm_package_config_awsS3ServerConfigOverridePath ./privateserverconfig.json && aws s3 --profile $npm_package_config_awsProfile cp $npm_package_config_awsS3ClientConfigOverridePath ./wwwroot/privateconfig.json"


### PR DESCRIPTION
* Don't update package-lock.json in `npm run deploy`, avoiding "(with location modifications)" message in the version.
* Do an AWS thing right at the start of deployment in order to prompt for the MFA token, rather than asking for it much later when you've probably forgotten you're deploying.
* Remove `preserveTimestamps` option for copying files in `make-package`; it seems to be broken for copying read-only files.