### PR TITLE
Use `npm ci` instead of `npm install` for deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "gulp": "gulp",
     "postinstall": "echo 'Installation successful. What to do next:\\n  npm start       # Starts the server on port 3001\\n  gulp watch      # Builds TerriaMap and dependencies, and rebuilds if files change.'",
     "hot": "webpack-dev-server --inline --config buildprocess/webpack.config.hot.js --hot --host 0.0.0.0",
-    "deploy": "aws --profile $npm_package_config_awsProfile s3 ls && rm -rf node_modules && npm install --no-package-lock && npm run deploy-without-reinstall",
+    "deploy": "aws --profile $npm_package_config_awsProfile s3 ls && npm ci && npm run deploy-without-reinstall",
     "deploy-without-reinstall": "gulp clean && gulp release && npm run deploy-current",
     "deploy-current": "npm run get-deploy-overrides && gulp make-package --serverConfigOverride ./privateserverconfig.json --clientConfigOverride ./wwwroot/privateconfig.json && cd deploy/aws && ./stack create && cd ../..",
     "get-deploy-overrides": "aws s3 --profile $npm_package_config_awsProfile cp $npm_package_config_awsS3ServerConfigOverridePath ./privateserverconfig.json && aws s3 --profile $npm_package_config_awsProfile cp $npm_package_config_awsS3ClientConfigOverridePath ./wwwroot/privateconfig.json"


### PR DESCRIPTION
https://docs.npmjs.com/cli/ci.html
`npm ci` removes `node_modules` before starting, runs faster, won't modify `package-lock.json`, and exits with an error if `package-lock.json` is out of sync with dependencies. This should help avoid the `(with local modifications)` thing in deployed version specs.