### PR TITLE
Varnish tweaks

### DIFF
--- a/deploy/varnish/default.vcl
+++ b/deploy/varnish/default.vcl
@@ -6,7 +6,7 @@ backend default {
 }
 
 sub vcl_recv {
-  if (req.url ~ "^/proxy"){
+  if (req.method == "GET" && req.url ~ "^/proxy"){
     return (hash);
   }
 }
@@ -14,5 +14,17 @@ sub vcl_recv {
 sub vcl_backend_response {
   if (beresp.status >= 400) {
     set beresp.ttl = 0s;
+  }
+
+  if (bereq.url ~ "https?://stat\.data\.abs\.gov\.au/sdmx-json") {
+    // Remove the cookie so that the response can be cached.
+    unset beresp.http.Set-Cookie;
+
+    // The ABS SDMX-JSON API has a habit of returning HTML
+    // responses with a 200 OK code on error.  Detect this and
+    // don't cache it.
+    if (beresp.status == 200 && beresp.http.Content-Type ~ "text/html") {
+      set beresp.ttl = 0s;
+    }
   }
 }


### PR DESCRIPTION
Incorporate minor varnish config tweaks from map.terria.io and NationalMap:
* Only ever cache GET requests.
* Disable caching for proxied errors from the ABS SDMX server (`text/html` responses when we expect JSON).