### PR TITLE
added aws managed ssm policy to instance profile

### DIFF
--- a/deploy/aws/stack.json
+++ b/deploy/aws/stack.json
@@ -303,6 +303,9 @@
           ]
         },
         "Path": "/",
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+        ],
         "Policies": [
           {
             "PolicyDocument": {


### PR DESCRIPTION
As discussed a few months back - This change should mean that all future terria stacks based on this one will include the AWS managed SSM policy allowing inventory management etc. 

This was previously not acheivable here as AWS' recommended policy gave full s3 access which was too open to be 'sanely' considered.

They've since provided a new ssm policy which is much better and should work here nicely :)