### PR TITLE
Disable sourcemap breaking mobx builds

### DIFF
--- a/buildprocess/webpack.config.js
+++ b/buildprocess/webpack.config.js
@@ -17,7 +17,8 @@ module.exports = function(devMode, hot) {
             sourcePrefix: '', // to avoid breaking multi-line string literals by inserting extra tabs.
             globalObject: '(self || window)' // to avoid breaking in web worker (https://github.com/webpack/webpack/issues/6642)
         },
-        devtool: 'source-map', //devMode ? 'cheap-inline-source-map' : 'source-map',
+        // devtool: 'source-map', //devMode ? 'cheap-inline-source-map' : 'source-map',
+        devtool: devMode ? 'source-map' : 'eval',
         module: {
             rules: [
                 {
@@ -56,8 +57,10 @@ module.exports = function(devMode, hot) {
                                   '@babel/preset-react'
                                 ],
                                 plugins: [
+                                    'babel-plugin-styled-components',
                                     'babel-plugin-jsx-control-statements',
-                                    '@babel/plugin-transform-modules-commonjs'
+                                    '@babel/plugin-transform-modules-commonjs',
+                                    require.resolve('@babel/plugin-syntax-dynamic-import')
                                 ]
                             }
                         },
@@ -107,15 +110,14 @@ module.exports = function(devMode, hot) {
                         {
                             loader: 'css-loader',
                             options: {
-                                sourceMap: true,
                                 modules: true,
                                 camelCase: true,
                                 localIdentName: 'tm-[name]__[local]',
                                 importLoaders: 2
                             }
                         },
-                        'resolve-url-loader?sourceMap',
-                        'sass-loader?sourceMap'
+                        'resolve-url-loader',
+                        'sass-loader'
                     ]
                 }
             ]


### PR DESCRIPTION
Can revert when we trace down root cause