### PR TITLE
Update Deployment for k8s 1.16 on next

### DIFF
--- a/deploy/helm/terria/charts/terriamap/templates/deployment.yaml
+++ b/deploy/helm/terria/charts/terriamap/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ printf "%s-%s" .Release.Name "terriamap" | trunc 63 | trimSuffix "-" | quote }}
@@ -7,6 +7,9 @@ spec:
   strategy:
     rollingUpdate:
       maxUnavailable: {{ .Values.global.rollingUpdate.maxUnavailable | default 0 }}
+  selector:
+    matchLabels:
+      service: {{ printf "%s-%s" .Release.Name "terriamap" | trunc 63 | trimSuffix "-" | quote }}
   template:
     metadata:
       labels:


### PR DESCRIPTION
This change to the Helm chart updates the Deployment to work on Kubernetes 1.16.