### PR TITLE
Make TerriaMap deafult to one-button disclaimer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,3 +21,5 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - run: npm ci
     - run: npm run gulp lint release
+      env:
+        NODE_OPTIONS: --max_old_space_size=4096

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Change Log
 * Added default help content & `languageOverrides.json` for i18n
 * Add back updateApplicationOnMessageFromParentWindow
 * Update youtube urls to nocookie version
+* Removed cancel/deny button from global disclaimer unless `globalDisclaimer.afterDenyLocation` is set with a website to navigate to.
 
 ### Next Release
 

--- a/index.js
+++ b/index.js
@@ -108,9 +108,9 @@ module.exports = terria.start({
                     title: (globalDisclaimer.title !== undefined) ? globalDisclaimer.title : 'Warning',
                     confirmText: (globalDisclaimer.buttonTitle || "Ok"),
                     denyText: (globalDisclaimer.denyText || "Cancel"),
-                    denyAction: function() {
-                        window.location = globalDisclaimer.afterDenyLocation || "https://terria.io/";
-                    },
+                    denyAction: globalDisclaimer.afterDenyLocation ? function() {
+                        window.location = globalDisclaimer.afterDenyLocation;
+                    } : undefined,
                     width: 600,
                     height: 550,
                     message: message,

--- a/package-lock.json
+++ b/package-lock.json
@@ -5046,9 +5046,9 @@
       }
     },
     "core-js": {
-      "version": "3.11.3",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.11.3.tgz",
-      "integrity": "sha512-DFEW9BllWw781Op5KdYGtXfj3s9Cmykzt16bY6elaVuqXHCUwF/5pv0H3IJ7/I3BGjK7OeU+GrjD1ChCkBJPuA==",
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.12.1.tgz",
+      "integrity": "sha512-Ne9DKPHTObRuB09Dru5AjwKjY4cJHVGu+y5f7coGn1E9Grkc3p2iBwE9AI/nJzsE29mQF7oq+mhYYRqOMFN1Bw==",
       "dev": true
     },
     "core-js-compat": {
@@ -9229,12 +9229,12 @@
       }
     },
     "is-boolean-object": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.0.tgz",
-      "integrity": "sha512-a7Uprx8UtD+HWdyYwnD1+ExtTgqQtD2k/1yJgtXP6wnMm8byhkoTZRl+95LLThpzNZJ5aEvi46cdH+ayMFRwmA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.1.tgz",
+      "integrity": "sha512-bXdQWkECBUIAcCkeH1unwJLIpZYaa5VvuygSyS/c2lf719mTKZDU5UdDRlpd01UjADgmW8RfqaP+mRaVPdr/Ng==",
       "dev": true,
       "requires": {
-        "call-bind": "^1.0.0"
+        "call-bind": "^1.0.2"
       }
     },
     "is-buffer": {
@@ -9370,9 +9370,9 @@
       }
     },
     "is-number-object": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.4.tgz",
-      "integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.5.tgz",
+      "integrity": "sha512-RU0lI/n95pMoUKu9v1BZP5MBcZuNSVJkMkAG2dJqC4z2GlkGUNeH68SuHuBKBD/XFe+LHZ+f9BKkLET60Niedw==",
       "dev": true
     },
     "is-path-cwd": {
@@ -9733,11 +9733,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
-      "dev": true
-    },
-    "jsonschema": {
-      "version": "github:terriajs/jsonschema#55cedb27a265bbae2b366a3824863c586c5d34cf",
-      "from": "github:terriajs/jsonschema",
       "dev": true
     },
     "jsprim": {
@@ -14810,19 +14805,19 @@
           "dev": true
         },
         "is-regex": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
-          "integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
+          "integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
           "dev": true,
           "requires": {
             "call-bind": "^1.0.2",
-            "has-symbols": "^1.0.1"
+            "has-symbols": "^1.0.2"
           }
         },
         "object-inspect": {
-          "version": "1.10.2",
-          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.2.tgz",
-          "integrity": "sha512-gz58rdPpadwztRrPjZE9DZLOABUpTGdcANUgOwBFO1C+HZZhePoP83M65WGDmbpwFYJSWqavbl4SgDn4k8RYTA==",
+          "version": "1.10.3",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
+          "integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==",
           "dev": true
         },
         "object.assign": {
@@ -15393,9 +15388,9 @@
       "dev": true
     },
     "terriajs": {
-      "version": "8.0.0-alpha.79",
-      "resolved": "https://registry.npmjs.org/terriajs/-/terriajs-8.0.0-alpha.79.tgz",
-      "integrity": "sha512-m54+1C0ylWnRu/x/NONLrDJ2J0DfS1UGNmr/ZqT7eUgokdBa1RpB6XftJsj0LCRYxqoDSz03xlLjp6i2/M157w==",
+      "version": "8.0.0-alpha.80",
+      "resolved": "https://registry.npmjs.org/terriajs/-/terriajs-8.0.0-alpha.80.tgz",
+      "integrity": "sha512-yW+ZAwBge3oro0rvgo97DCYrPenJr2/AgX8BuL7aK3JjisQtnG4hnIf8qx29tHT/1QqJCUkH5UvmFQXseCRl3g==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.3.3",
@@ -15598,7 +15593,6 @@
       "integrity": "sha1-cOwp4RCrn2QpcYGYC+Jp8PRG23Q=",
       "dev": true,
       "requires": {
-        "jsonschema": "github:terriajs/jsonschema",
         "when": "^3.7.7",
         "yargs": "^3.32.0"
       },

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "semver": "^5.0.0",
     "style-loader": "^0.23.1",
     "svg-sprite-loader": "4.1.3",
-    "terriajs": "8.0.0-alpha.79",
+    "terriajs": "8.0.0-alpha.80",
     "terriajs-catalog-editor": "^0.2.0",
     "terriajs-cesium": "1.81.0",
     "terriajs-schema": "latest",


### PR DESCRIPTION
Goes with https://github.com/TerriaJS/terriajs/pull/5473.

Changes default TerriaMap global disclaimer cancel button behaviour.

**Before this PR:** Clicking cancel navigates to https://terria.io
**With this PR but without https://github.com/TerriaJS/terriajs/pull/5473:** Clicking cancel does nothing
**With this PR and with https://github.com/TerriaJS/terriajs/pull/5473:** No cancel button
