### PR TITLE
Update docker file to use node 10

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Docker image for the primary terria map application server
-FROM node:8
+FROM node:10
 
 RUN apt-get update && apt-get install -y gdal-bin
 


### PR DESCRIPTION
Update docker file to use node 10 --- in case the [default CA built in the source](https://github.com/nodejs/node-v0.x-archive/blob/v0.10.30/src/node_root_certs.h) was too old:

