### PR TITLE
add fontImports to index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,6 +121,15 @@ module.exports = terria.start({
             }
         }
 
+        // Add font-imports
+        const fontImports = terria.configParameters.theme?.fontImports;
+        if (fontImports) {
+          const styleSheet = document.createElement("style");
+          styleSheet.type = "text/css";
+          styleSheet.innerText = fontImports;
+          document.head.appendChild(styleSheet);
+        }
+
         render(terria, [], viewState);
     } catch (e) {
         console.error(e);


### PR DESCRIPTION
This is needed due to changes made in https://github.com/TerriaJS/terriajs/pull/6100

It moves fontImports from 

- https://github.com/TerriaJS/terriajs/pull/6100/files#diff-0f560813c9eb05adde52919f9ab57c87f8af770d2b6e5ea83a7569c4625d23bc
- to https://github.com/TerriaJS/TerriaMap/pull/571/files#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346