### PR TITLE
Remove unnecessary gulp translation merging step

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 Change Log
 ==========
 
+### 2022-05-31
+
+**Breaking changes:**
+
+* TerriaMap no longer merges `lib/Language/en/translation.json` with terriajs' translation file. You should now use `wwwroot/languages/{{lng}}/languageOverrides.json` to override strings in terriajs' translation file(s) or to add additional strings for your map.
+
 ### 2022-03-14
 
 **Breaking changes:**

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -273,15 +273,6 @@ gulp.task('render-datasource-templates', function(done) {
     var JSON5 = require('json5');
     var templateDir = 'datasources';
 
-    // until https://github.com/TerriaJS/terriajs/pull/4227 is ready,
-    // merge in translation overrides via this task
-    var json5 = require('json5');
-    var translationFromLibPath = path.join(getPackageRoot('terriajs'), 'lib', 'Language', 'en', 'translation.json');
-    var translationFromLib = json5.parse(fs.readFileSync(translationFromLibPath, 'utf8')) || {};
-    var translationFromMap = json5.parse(fs.readFileSync(path.resolve(__dirname, 'lib', 'Language', 'en', 'translation.json'), 'utf8')) || {};
-    var translation = {...translationFromLib, ...translationFromMap};
-    fs.writeFileSync(translationFromLibPath, JSON.stringify(translation, null, 2));
-
     try {
         fs.accessSync(templateDir);
     } catch (e) {


### PR DESCRIPTION
Merge after https://github.com/TerriaJS/terriajs/pull/6219 is published.

- [x] Add breaking change message to CHANGES.md that translation.json is no longer merged and app makers should use languageOverrides.json