### PR TITLE
Pin @types/react to 17.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,9 @@
       "include": "wwwroot node_modules devserverconfig.json index.js package.json version.js"
     }
   },
+  "resolutions": {
+    "@types/react": "^17.0.3"
+  },
   "devDependencies": {
     "@babel/core": "^7.16.0",
     "@babel/eslint-parser": "^7.12.16",


### PR DESCRIPTION
@types/styled-components has its dependency for @types/react set to "*" which breaks our CI as it tries to build the map after deleting yarn.lock. This PR pins the dependency to 17.x.x.