### PR TITLE
Remove GDAL (not used in terriajs version 8+)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,6 @@ RUN yarn gulp release
 # deploy container
 FROM node:14-slim as deploy
 
-RUN apt-get update && apt-get install -y gdal-bin
-
 USER node
 
 WORKDIR /app

--- a/deploy/aws/user-data
+++ b/deploy/aws/user-data
@@ -12,7 +12,6 @@ packages:
  - python-pip
  - nodejs
  - varnish
- - gdal-bin
 
 # any files to create
 write_files:

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,8 +1,6 @@
 # Docker image for the primary terria map application server
 FROM node:14
 
-RUN apt-get update && apt-get install -y gdal-bin
-
 RUN mkdir -p /usr/src/app && mkdir -p /etc/config/client
 WORKDIR /usr/src/app/component
 COPY . /usr/src/app


### PR DESCRIPTION
Is there something that should replace this line? Or can we remove it entirely because we don't need GDAL?