### PR TITLE
Use just the start year (2012) in LICENSE.md

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -186,7 +186,7 @@ APPENDIX: How to apply the Apache License to your work.
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-Copyright 2012-2019 CSIRO's Data61 and Contributors
+Copyright 2012 CSIRO's Data61 and Contributors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
Changes the year in LICENSE.md to say just the start year, i.e, 2012. 