### PR TITLE
Release TerriaMap 0.0.5

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,9 +2,13 @@
 
 ### The Next Release
 
-**Breaking changes:**
+### `0.0.5`
+
+**2022-11-02**
 
 - TerriaMap no longer supports ejs templating for data sources. We suggest to use terria reference to manage a catalog in multiple files.
+- Update TerriaJS to `8.2.20`
+- Pin `"@types/lodash": "4.14.182"`(See https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/63021)
 
 ### `0.0.4`
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     ]
   },
   "name": "terriajs-map",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Geospatial catalog explorer based on TerriaJS.",
   "license": "Apache-2.0",
   "engines": {
@@ -44,7 +44,8 @@
     }
   },
   "resolutions": {
-    "@types/react": "^17.0.3"
+    "@types/react": "^17.0.3",
+    "@types/lodash": "4.14.182"
   },
   "devDependencies": {
     "@babel/core": "^7.16.0",
@@ -81,7 +82,7 @@
     "semver": "^5.0.0",
     "style-loader": "^0.23.1",
     "svg-sprite-loader": "4.1.3",
-    "terriajs": "8.2.17",
+    "terriajs": "8.2.20",
     "terriajs-cesium": "1.92.0-tile-error-provider-fix-2",
     "terriajs-schema": "latest",
     "ts-loader": "^5.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1619,10 +1619,10 @@
   dependencies:
     "@types/lodash" "*"
 
-"@types/lodash@*", "@types/lodash@^4.14.146", "@types/lodash@^4.14.172":
-  version "4.14.180"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.180.tgz#4ab7c9ddfc92ec4a887886483bc14c79fb380670"
-  integrity sha512-XOKXa1KIxtNXgASAnwj7cnttJxS4fksBRywK/9LzRV5YxrF80BXZIGeQSuoESQ/VkUj30Ae0+YcuHc15wJCB2g==
+"@types/lodash@*", "@types/lodash@4.14.182", "@types/lodash@^4.14.146", "@types/lodash@^4.14.172":
+  version "4.14.182"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.182.tgz#05301a4d5e62963227eaafe0ce04dd77c54ea5c2"
+  integrity sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q==
 
 "@types/math-expression-evaluator@^1.2.0":
   version "1.2.2"
@@ -5503,7 +5503,7 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.5.tgz#76c8584f4fc843db64702a6bd04ab7a8bd666da3"
   integrity sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==
 
-flexsearch@^0.7.21:
+flexsearch@0.7.21:
   version "0.7.21"
   resolved "https://registry.yarnpkg.com/flexsearch/-/flexsearch-0.7.21.tgz#0f5ede3f2aae67ddc351efbe3b24b69d29e9d48b"
   integrity sha512-W7cHV7Hrwjid6lWmy0IhsWDFQboWSng25U3VVywpHOTJnnAZNPScog67G+cVpeX9f7yDD21ih0WDrMMT+JoaYg==
@@ -8060,11 +8060,6 @@ mustache@^2.2.1:
   resolved "https://registry.yarnpkg.com/mustache/-/mustache-2.3.2.tgz#a6d4d9c3f91d13359ab889a812954f9230a3d0c5"
   integrity sha512-KpMNwdQsYz3O/SBS1qJ/o3sqUJ5wSb8gb0pul8CO0S56b9Y2ALm8zCfsjPXsqGFfoNBkDwZuZIAjhsZI03gYVQ==
 
-mutationobserver-shim@^0.3.1:
-  version "0.3.7"
-  resolved "https://registry.yarnpkg.com/mutationobserver-shim/-/mutationobserver-shim-0.3.7.tgz#8bf633b0c0b0291a1107255ed32c13088a8c5bf3"
-  integrity sha512-oRIDTyZQU96nAiz2AQyngwx1e89iApl2hN5AOYwyxLUB47UYsU3Wv9lJWqH5y/QdiYkc5HQLi23ZNB3fELdHcQ==
-
 mute-stdout@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/mute-stdout/-/mute-stdout-1.0.1.tgz#acb0300eb4de23a7ddeec014e3e96044b3472331"
@@ -9582,13 +9577,6 @@ rc-util@^5.16.1, rc-util@^5.19.2, rc-util@^5.3.0:
     "@babel/runtime" "^7.12.5"
     react-is "^16.12.0"
     shallowequal "^1.1.0"
-
-react-addons-pure-render-mixin@^15.6.0:
-  version "15.6.3"
-  resolved "https://registry.yarnpkg.com/react-addons-pure-render-mixin/-/react-addons-pure-render-mixin-15.6.3.tgz#5dc73af0fa32186dbc4887f20667b46d3f9caed7"
-  integrity sha512-e7F2OsLiyYGr9SHWHGlI/FfHRh+kbYx0hNfdN5zivHIf4vzeno7gsRJKXg71E35CpUCnre+JfM6UgWWgsvJBzA==
-  dependencies:
-    object-assign "^4.1.0"
 
 react-anything-sortable@^1.5.2:
   version "1.7.4"
@@ -11378,10 +11366,10 @@ terriajs-server@^3.3.4:
     when "^3.7.7"
     yargs "^13.2.4"
 
-terriajs@8.2.17:
-  version "8.2.17"
-  resolved "https://registry.yarnpkg.com/terriajs/-/terriajs-8.2.17.tgz#56ee00e05100fdd4cd4450b02e643d8be3a2b525"
-  integrity sha512-L7+BM8d3Osw4T7/FencGF1hpx+0PADKzL7dqDkHZ9KnxRITGcCJGayQYbm7JUyYqFVX8r+BtlY3Yvlm0K68QHQ==
+terriajs@8.2.20:
+  version "8.2.20"
+  resolved "https://registry.yarnpkg.com/terriajs/-/terriajs-8.2.20.tgz#e517ed3457a290544451b0cad2d50c378925fced"
+  integrity sha512-1Nm9AFez0FpKvvRbKmxk7fEJCUAZqm9qjyY0HP7Wbhl7cxZoS+qwM1zzHBnkYMmBENBk0cGAawnRepWHWYZhig==
   dependencies:
     "@babel/core" "^7.16.0"
     "@babel/parser" "^7.12.14"
@@ -11472,7 +11460,7 @@ terriajs@8.2.17:
     dompurify "^2.3.3"
     file-loader "^3.0.1"
     file-saver "^1.3.8"
-    flexsearch "^0.7.21"
+    flexsearch "0.7.21"
     geojson-vt "^3.2.1"
     gulp "^4.0.0"
     hammerjs "^2.0.6"
@@ -11498,7 +11486,6 @@ terriajs@8.2.17:
     mobx-utils "^5.4.1"
     moment "2.24.0"
     mustache "^2.2.1"
-    mutationobserver-shim "^0.3.1"
     papaparse "^5.2.0"
     pbf "^3.0.1"
     point-in-polygon "^1.0.1"
@@ -11508,7 +11495,6 @@ terriajs@8.2.17:
     raw-loader "^1.0.0"
     rc-slider "^9.7.2"
     react "^16.14.0"
-    react-addons-pure-render-mixin "^15.6.0"
     react-anything-sortable "^1.5.2"
     react-color "^2.19.3"
     react-datepicker "0.53.0"


### PR DESCRIPTION
Also:

- Update TerriaJS to `8.2.20`
- Pin `"@types/lodash": "4.14.182"`(See https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/63021)