### PR TITLE
Stop using node_modules/.bin for Windows compatibility

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -302,7 +302,7 @@ gulp.task("terriajs-server", function (done) {
   const child = spawn(
     "node",
     [
-      "./node_modules/.bin/terriajs-server",
+      require.resolve("terriajs-server/terriajs-server.js"),
       ...serverArgs.map((arg) => `--${arg}`)
     ],
     { detached: true, stdio: ["ignore", logFile, logFile] }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -295,7 +295,7 @@ gulp.task("terriajs-server", function (done) {
     default: { terriajsServerArg: [] }
   });
 
-  const logFile = fs.openSync("./terriajs-server.log", "a");
+  const logFile = fs.openSync("./terriajs-server.log", "w");
   const serverArgs = Array.isArray(options.terriajsServerArg)
     ? options.terriajsServerArg
     : [options.terriajsServerArg];

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -317,6 +317,9 @@ gulp.task("terriajs-server", function (done) {
       )
     );
   });
+  child.on("spawn", () => {
+    console.log("terriajs-server started - see terriajs-server.log for logs");
+  });
   // Intercept SIGINT, SIGTERM and SIGHUP, cleanup terriajs-server and re-send signal
   // May fail to catch some relevant signals on Windows
   // SIGINT: ctrl+c

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -337,6 +337,9 @@ gulp.task("terriajs-server", function (done) {
     child.kill("SIGTERM");
     process.kill(process.pid, "SIGHUP");
   });
+  process.on("exit", () => {
+    child.kill("SIGTERM");
+  });
 });
 
 gulp.task("build", gulp.series("copy-terriajs-assets", "build-app"));


### PR DESCRIPTION
Hopefully fixes error when attempting to run `yarn gulp dev` on Windows:

```
basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
          ^^^^^^^

SyntaxError: missing ) after argument list
    at Object.compileFunction (node:vm:360:18)
    at wrapSafe (node:internal/modules/cjs/loader:1124:15)
    at Module._compile (node:internal/modules/cjs/loader:1160:27)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1250:10)
    at Module.load (node:internal/modules/cjs/loader:1074:32)
    at Function.Module._load (node:internal/modules/cjs/loader:909:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
    at node:internal/main/run_main_module:22:47

```

(see https://github.com/TerriaJS/terriajs/discussions/6731#discussioncomment-6872744)