### PR TITLE
Update React and Typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,13 +35,14 @@
     }
   },
   "resolutions": {
-    "@types/react": "^17.0.3",
+    "@types/react": "^18.2.7",
     "@types/lodash": "4.14.182",
-    "@types/node": "^18.15.11"
+    "@types/node": "^18.15.11",
+    "@types/css-font-loading-module": "0.0.9"
   },
   "devDependencies": {
     "@babel/core": "^7.22.9",
-    "@babel/eslint-parser": "^7.12.16",
+    "@babel/eslint-parser": "^7.21.8",
     "@babel/preset-env": "^7.22.9",
     "@babel/preset-react": "^7.22.5",
     "babel-loader": "^8.2.3",
@@ -66,8 +67,8 @@
     "pretty-quick": "^1.10.0",
     "prop-types": "^15.6.0",
     "raw-loader": "^1.0.0",
-    "react": "^16.14.0",
-    "react-dom": "^16.14.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "redbox-react": "^1.3.6",
     "resolve-url-loader": "^3.0.1",
     "sass-loader": "^10",
@@ -77,7 +78,7 @@
     "terriajs": "8.3.2",
     "terriajs-cesium": "1.92.0-tile-error-provider-fix-2",
     "ts-loader": "^5.3.3",
-    "typescript": "^4.9.5",
+    "typescript": "^5.2.2",
     "urijs": "^1.18.12",
     "url-loader": "^1.1.2",
     "webpack": "~4.46.0",


### PR DESCRIPTION
Goes with https://github.com/TerriaJS/terriajs/pull/6902

After a TerriaJS release, regenerate yarn.lock before merging to fix build failure.