### PR TITLE
Add Dependabot for Github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: "main"


### PR DESCRIPTION
Dependabot will submit pull requests
when packages get new versions released.
After merging this, Dependabot should
open pull requests that resolve the warnings
for the workflows in the actions tab,
as seen here for example:

https://github.com/TerriaJS/TerriaMap/actions/runs/8150265114

Link to Dependabot documentation:

https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot