### PR TITLE
De-duplicate code in gulpfile and fixup helm files

### DIFF
--- a/deploy/helm/docker-registry.yml
+++ b/deploy/helm/docker-registry.yml
@@ -1,3 +1,0 @@
-persistence:
-  enabled: true
-  storageClass: standard

--- a/deploy/helm/example-prod.yml
+++ b/deploy/helm/example-prod.yml
@@ -2,4 +2,4 @@ global:
   rollingUpdate:
     maxUnavailable: 1
   image:
-    tag: "0.0.6"
+    tag: "0.1.1"

--- a/deploy/helm/kube-registry-proxy.yml
+++ b/deploy/helm/kube-registry-proxy.yml
@@ -1,4 +1,0 @@
-registry:
-  host: docker-registry-docker-registry
-  port: 5000
-hostPort: 5000

--- a/deploy/helm/terria/charts/terriamap/values.yaml
+++ b/deploy/helm/terria/charts/terriamap/values.yaml
@@ -1,15 +1,17 @@
 nodePort:
 image:
-  #repository: ghcr.io/terriajs
-  #tag: latest
-  #full: terrimap:0.0.6
+  # By default this pulls ghcr.io/terriajs/terrimap:latest
+  # Set "full" to specify a custom terriamap image to be used
+  # Or you can set "repository" or "tag" if required
+  # full: "ghcr.io/terriajs/terriamap:0.1.1"
+  # repository: ghcr.io/terriajs
+  # tag: latest
   pullPolicy: Always
 clientConfig:
   initializationUrls:
     - helm
     - terria
   parameters:
-    bingMapsKey: AkaOmRFtjAb71cXgLwAGtLbj2RpkPKtVqAIroFQsocfurCBILxIeAWPkil7hhRy_
     disclaimer:
       text: "Disclaimer: This map must not be used for navigation or precise spatial analysis"
       url: "http://google.com"


### PR DESCRIPTION
- **Improve helm files**
- **Use terriajs-server gulp task from terriajs**

I moved the "terriajs-server" gulp task to a separate file in the terriajs repo so that TerriaMap and terriajs could use the same code to run terriajs-server (with a different default port). This is to reduce code duplication. 
