### PR TITLE
Dockerfile: keep /app owned by node:node

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,9 @@ USER node
 
 WORKDIR /app
 
-COPY --from=build /app/wwwroot wwwroot
-COPY --from=build /app/node_modules node_modules
+# Without the chown when copying directories, wwwroot is owned by root:root.
+COPY --from=build --chown=node:node /app/wwwroot wwwroot
+COPY --from=build --chown=node:node /app/node_modules node_modules
 COPY --from=build /app/devserverconfig.json serverconfig.json
 COPY --from=build /app/index.js index.js
 COPY --from=build /app/package.json package.json


### PR DESCRIPTION
The node_modules and wwwroot directories
are owned by root in the deployment image.
Make sure they end up as owned by node:node
like everything else under /app.