### PR TITLE
Clarify that announcements section doesn't specify every terriajs version upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ To get in touch:
 
 ---
 
+## Major announcements
+
+Following is a list of major announcements and upgrades that may affect users maintaining a fork (copied from [TerriaJS announcements](https://github.com/TerriaJS/terriajs/discussions/categories/announcements)). For a full list of changes to TerriaMap, including the latest versions of TerriaJS included with each release please refer to [CHANGES.md](https://github.com/TerriaJS/TerriaMap/blob/main/CHANGES.md). 
+
 ### We have released TerriaJS v8.3.0 (2023-05-22)
 
 Terriajs version `8.3.0` includes a few breaking changes:


### PR DESCRIPTION
TerriaMap users may expect every terriajs version upgrade to be announced here. This attempts to clarify that only major upgrades that may require significant work for a TerriaMap fork maintainer will be announced here.