### PR TITLE
Update to svg-sprite-loader 6.0.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "sass-loader": "^10",
     "semver": "^5.0.0",
     "style-loader": "^0.23.1",
-    "svg-sprite-loader": "4.1.3",
+    "svg-sprite-loader": "^6.0.11",
     "terriajs": "8.7.1",
     "terriajs-cesium": "8.0.0",
     "ts-loader": "^5.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10790,7 +10790,7 @@ sver-compat@^1.5.0:
     es6-iterator "^2.0.1"
     es6-symbol "^3.1.1"
 
-svg-baker-runtime@^1.4.0:
+svg-baker-runtime@^1.4.0, svg-baker-runtime@^1.4.7:
   version "1.4.7"
   resolved "https://registry.yarnpkg.com/svg-baker-runtime/-/svg-baker-runtime-1.4.7.tgz#f4720637f5b6202eef6378d81f1fead0815f8a4e"
   integrity sha512-Zorfwwj5+lWjk/oxwSMsRdS2sPQQdTmmsvaSpzU+i9ZWi3zugHLt6VckWfnswphQP0LmOel3nggpF5nETbt6xw==
@@ -10799,7 +10799,7 @@ svg-baker-runtime@^1.4.0:
     mitt "1.1.2"
     svg-baker "^1.7.0"
 
-svg-baker@^1.4.0, svg-baker@^1.7.0:
+svg-baker@^1.4.0, svg-baker@^1.5.0, svg-baker@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/svg-baker/-/svg-baker-1.7.0.tgz#8367f78d875550c52fe4756f7303d5c5d7c2e9a7"
   integrity sha512-nibslMbkXOIkqKVrfcncwha45f97fGuAOn1G99YwnwTj8kF9YiM6XexPcUso97NxOm6GsP0SIvYVIosBis1xLg==
@@ -10831,6 +10831,20 @@ svg-sprite-loader@4.1.3:
     loader-utils "^1.1.0"
     svg-baker "^1.4.0"
     svg-baker-runtime "^1.4.0"
+    url-slug "2.0.0"
+
+svg-sprite-loader@^6.0.11:
+  version "6.0.11"
+  resolved "https://registry.yarnpkg.com/svg-sprite-loader/-/svg-sprite-loader-6.0.11.tgz#a4d60cee3d74232a2c17d31c73a2008295f61220"
+  integrity sha512-TedsTf8wsHH6HgdwKjUveDZRC6q5gPloYV8A8/zZaRWP929J7x6TzQ6MvZFl+YYDJuJ0Akyuu/vNVJ+fbPuYXg==
+  dependencies:
+    bluebird "^3.5.0"
+    deepmerge "1.3.2"
+    domready "1.0.8"
+    escape-string-regexp "1.0.5"
+    loader-utils "^1.1.0"
+    svg-baker "^1.5.0"
+    svg-baker-runtime "^1.4.7"
     url-slug "2.0.0"
 
 table@^6.0.9:


### PR DESCRIPTION
This fixes security issues
in dependencies.

Same commit in TerriaJS:
https://github.com/TerriaJS/terriajs/pull/7117