### PR TITLE
CI: also test on Node 22.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [16.x, 18.x, 20.x, 22.x]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
The terriajs test suite passes
and this will be an LTS release
in 6 months, so add it to the build
matrix.