### PR TITLE
Dockerfile: fix casing warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # develop container
-FROM node:16 as develop
+FROM node:16 AS develop
 
 # build container
-FROM node:16 as build
+FROM node:16 AS build
 USER node
 
 COPY --chown=node:node . /app
@@ -13,7 +13,7 @@ RUN yarn install --network-timeout 1000000
 RUN yarn gulp release
 
 # deploy container
-FROM node:16-slim as deploy
+FROM node:16-slim AS deploy
 
 USER node
 


### PR DESCRIPTION
This fixes the warning:

FromAsCasing: 'as' and 'FROM' keywords' casing do not match

emitted from recent versions of Docker.