### PR TITLE
Override default title with appName on app start.

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,6 +81,13 @@ module.exports = terria
     terria.raiseErrorToUser(e);
   })
   .finally(function () {
+    // Override the default document title with appName. Check first for default
+    // title, because user might have already customized the title in
+    // index.ejs
+    if (document.title === "Terria Map") {
+      document.title = terria.appName;
+    }
+
     terria.loadInitSources().then((result) => result.raiseError(terria));
 
     try {


### PR DESCRIPTION
Fixes https://github.com/TerriaJS/TerriaMap/issues/690
Supersedes https://github.com/TerriaJS/terriajs/pull/7265

For various reasons, it is best to change the page title in terriamap instead of from TerriaJS.