### PR TITLE
Remove invalid option `disable` for mini-css-extract-plugin.

### DIFF
--- a/buildprocess/webpack.config.js
+++ b/buildprocess/webpack.config.js
@@ -141,14 +141,14 @@ module.exports = function (devMode, hot) {
         }
       ]
     },
-    plugins: [
-      new MiniCssExtractPlugin({
-        filename: "TerriaMap.css",
-        disable: hot,
-        ignoreOrder: true,
-        allChunks: true
-      })
-    ],
+    plugins: hot
+      ? []
+      : [
+          new MiniCssExtractPlugin({
+            filename: "TerriaMap.css",
+            ignoreOrder: true
+          })
+        ],
     resolve: {
       alias: {},
       modules: ["node_modules"]


### PR DESCRIPTION
TerriaJS PR https://github.com/TerriaJS/terriajs/pull/7210 upgrades style-loader and mini-css-extract-plugin from really old versions to latest ones compatible with webpack. They have strict checks for invalid options.

 `disable` and `allChunks` appears to be options from [a previous version](https://github.com/TerriaJS/TerriaMap/blame/ff7c49703300b3fde56def5f11b4dc8d5577388c/buildprocess/webpack.config.js#L108) of the plugin called [extract-text-webpack-plugin](https://www.npmjs.com/package/extract-text-webpack-plugin) which is not valid for `mini-css-extract-plugin`.

This change to terriamap is required before merging #7210.