### PR TITLE
Add openstreetmap as a default basemap.

### DIFF
--- a/wwwroot/init/simple.json
+++ b/wwwroot/init/simple.json
@@ -762,7 +762,7 @@
   ],
   "viewerMode": "3dSmooth",
   "baseMaps": {
-    "defaultBaseMapId": "basemap-positron",
-    "previewBaseMapId": "basemap-positron"
+    "defaultBaseMapId": "basemap-openstreetmap",
+    "previewBaseMapId": "basemap-natural-earth-II"
   }
 }


### PR DESCRIPTION
Depends on https://github.com/TerriaJS/terriajs/pull/7325
- Add OpenStreetMap as replacement to default Carto basemap which were [removed](https://github.com/TerriaJS/terriajs/pull/7314) due to license issues.
- Also switches preview map to natural earth II



