### PR TITLE
Remove unused semver dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "resolve-url-loader": "^5.0.0",
     "sass": "^1.81.0",
     "sass-loader": "^16.0.3",
-    "semver": "^5.0.0",
     "style-loader": "^4.0.0",
     "svg-sprite-loader": "^6.0.11",
     "terriajs": "8.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8983,11 +8983,6 @@ semver-greatest-satisfied-range@^2.0.0:
   dependencies:
     sver "^1.8.3"
 
-semver@^5.0.0:
-  version "5.7.2"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.2.tgz#48d55db737c3287cd4835e17fa13feace1c41ef8"
-  integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
-
 semver@^6.3.0, semver@^6.3.1:
   version "6.3.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"


### PR DESCRIPTION
This entered the tree in commit 49a78699d,
but the code in gulpfile.js is no longer
preseent, so remove the now unused
dependency.