### PR TITLE
Fix for copying binary files in gulp 5.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Change Log
 
+#### next release (0.2.3)
+
+- Upgraded gulp to version 5
+  - Gulp 5 defaults to encoding copied files as utf-8, had turn off encoding by setting `encoding: false` to correctly copy binary assets from dependencies.
+
 ### `0.2.2`
 
 **2024-11-22**

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -164,7 +164,7 @@ gulp.task("copy-terriajs-assets", function () {
   var destPath = path.resolve(__dirname, "wwwroot", "build", "TerriaJS");
 
   return gulp
-    .src([sourceGlob], { base: terriaWebRoot })
+    .src([sourceGlob], { base: terriaWebRoot, encoding: false })
     .pipe(gulp.dest(destPath));
 });
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "fork-ts-checker-notifier-webpack-plugin": "^6.0.0",
     "fork-ts-checker-webpack-plugin": "^6.0.0",
     "fs-extra": "^7.0.1",
-    "gulp": "^4.0.0",
+    "gulp": "^5.0.0",
     "husky": "^8.0.3",
     "is-subdir": "^1.2.0",
     "json5": "^2.1.0",


### PR DESCRIPTION
Gulp5 requires passing `encoding: false` when copying binary files to prevent re-encoding as utf8.

Requires https://github.com/TerriaJS/terriajs/pull/7340