### PR TITLE
index.js: fix arguments to ViewState

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,8 @@ registerCustomComponentTypes(terria);
 
 // Create the ViewState before terria.start so that errors have somewhere to go.
 const viewState = new ViewState({
-  terria: terria
+  terria: terria,
+  catalogSearchProvider: undefined
 });
 
 registerCatalogMembers();


### PR DESCRIPTION
There are two arguments required
for ViewStateOptions, so put in
a second argument with an undefined
value which is what is used
at other call sites.

This mirrors the same change in terriajs:
https://github.com/TerriaJS/terriajs/pull/7204