### PR TITLE
loadPlugins: fix type error

### DIFF
--- a/lib/Core/loadPlugins.ts
+++ b/lib/Core/loadPlugins.ts
@@ -18,7 +18,7 @@ async function loadPlugins(
   try {
     const pluginsList = getPluginsList();
     const loadPromises = pluginsList.map((promise) => {
-      const pluginContext = createPluginContext(viewState);
+      const pluginContext = createPluginContext(viewState, undefined);
       return promise
         .then(({ default: plugin }) => {
           try {


### PR DESCRIPTION
The function expects two arguments,
so give it undefined as second
argument.