### PR TITLE
tsconfig: extend from node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ datasources/00_National_Data_Sets.json
 /error.log
 /output.log
 privateserverconfig.json
+ts-out/
 wwwroot/privateconfig.json
 deploy/packages/
 deploy/work/

--- a/.prettierignore
+++ b/.prettierignore
@@ -20,6 +20,7 @@ datasources/00_National_Data_Sets.json
 /error.log
 /output.log
 privateserverconfig.json
+ts-out/
 wwwroot/privateconfig.json
 deploy/packages/
 deploy/work/

--- a/lib/ThirdParty/global.d.ts
+++ b/lib/ThirdParty/global.d.ts
@@ -1,0 +1,1 @@
+declare module "*.html";

--- a/lib/ThirdParty/styled-components/index.d.ts
+++ b/lib/ThirdParty/styled-components/index.d.ts
@@ -1,0 +1,24 @@
+// Copy of lib/ThirdParty/styled-components from terriajs, but with updated
+// import path for terriaTheme.
+
+// Pull in the css prop type addition to react attributes
+/// <reference types="styled-components/cssprop" />
+
+// import your custom theme
+import { CSSProp } from "styled-components";
+import { terriaTheme } from "terriajs/lib/ReactViews/StandardUserInterface/StandardTheme";
+
+type Theme = typeof terriaTheme;
+
+declare module "styled-components" {
+  export interface DefaultTheme extends Theme {}
+}
+
+// See https://github.com/styled-components/styled-components/issues/2528
+// .css isn't included in @types/styled-components because it has to be enabled
+// through a babel plugin or macro
+declare module "react" {
+  interface Attributes {
+    css?: CSSProp;
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,20 @@
 {
-  "extends": "terriajs/tsconfig.json"
+  "extends": "./node_modules/terriajs/tsconfig",
+  "compilerOptions": {
+    "outDir": "ts-out",
+    "maxNodeModuleJsDepth": 5,
+    "typeRoots": [
+      "./node_modules/",
+      "./node_modules/@types/",
+      "./node_modules/terriajs/lib/ThirdParty",
+      "../node_modules/",
+      "../node_modules/@types/",
+      "../../node_modules/",
+      "../../node_modules/@types/",
+      "../../../node_modules/",
+      "../../../node_modules/@types/"
+    ],
+    "types": ["global", "terriajs-cesium", "terriajs-cesium-extra"]
+  },
+  "include": ["./lib/**/*", "./buildprocess/**/*"]
 }


### PR DESCRIPTION
Depends on: #729 

There is no "terriajs" directory
in this repository, so import
tsconfig.json from the terriajs
directory inside node_modules
instead, just like the ESLint
configuration does.

This requires re-defining outDir,
typeRoots, and include to the same
values that they have in terriajs,
since they will otherwise be relative
to the node_modules tsconfig.json.

The types option requires including
a couple of lib/ThirdParty directories
in terriajs.

The maxNodeModuleJsDepth parameter
is required for not getting errors
about implicit any types on jsx
imports in terriajs source code.