### PR TITLE
babel: use preset-typescript as name

### DIFF
--- a/buildprocess/webpack.config.js
+++ b/buildprocess/webpack.config.js
@@ -47,7 +47,7 @@ module.exports = function (devMode) {
                     }
                   ],
                   ["@babel/preset-react", { runtime: "automatic" }],
-                  ["@babel/typescript", { allowNamespaces: true }]
+                  ["@babel/preset-typescript", { allowNamespaces: true }]
                 ],
                 plugins: [
                   ["@babel/plugin-proposal-decorators", { legacy: true }],


### PR DESCRIPTION
This is the commit corresponding to
https://github.com/TerriaJS/terriajs/pull/7487.