### PR TITLE
Change loader to single background

### DIFF
--- a/entry.js
+++ b/entry.js
@@ -12,17 +12,8 @@ function createLoader() {
   loaderDiv.classList.add("loader-ui");
   const loaderGif = document.createElement("img");
   loaderGif.src = globeGif;
-  const loaderLeft = document.createElement("div");
-  loaderLeft.classList.add("loader-ui-left");
-  const loaderGrabber = document.createElement("div");
-  loaderGrabber.classList.add("loader-ui-grabber");
-  const loaderRight = document.createElement("div");
-  loaderRight.classList.add("loader-ui-right");
-  loaderRight.appendChild(loaderGif);
+  loaderDiv.appendChild(loaderGif);
 
-  loaderDiv.appendChild(loaderLeft);
-  loaderDiv.appendChild(loaderRight);
-  loaderDiv.appendChild(loaderGrabber);
   loaderDiv.style.backgroundColor = "#383F4D";
   document.body.appendChild(loaderDiv);
 

--- a/lib/Styles/loader.css
+++ b/lib/Styles/loader.css
@@ -1,4 +1,4 @@
-.loader-ui-right img {
+.loader-ui img {
   display: block;
   margin: calc(50vh - 150px) auto;
 }
@@ -11,33 +11,6 @@
     top: 0;
     width: 100vw;
     height: 100vh;
-  }
-
-  .loader-ui-left {
-    background: #3f4854;
-    height: 100vh;
-    width: 350px;
-    position: relative;
-  }
-
-  .loader-ui-right {
-    height: 100vh;
-    width: calc(100% - 350px);
-  }
-  .loader-ui-grabber {
-    left: 350px;
-    top: 70px;
-    height: 15px;
-    width: 31px;
-    position: absolute;
-    margin-left: -15px;
-    transform: perspective(10px) rotateY(10deg);
-    padding: 8px 0px;
-    border-width: 0px 1px 0px 0px;
-    border-right: 1px solid #3f4854;
-    border-radius: 0px 2px 2px 0px;
-    background: #3f4854;
-    z-index: -2;
   }
 }
 


### PR DESCRIPTION
With new UI no longer makes sense for loader to show app `shell`, use single colour background:

![Screenshot 2025-03-18 at 10 00 49 am](https://github.com/user-attachments/assets/04dc20ad-3cf0-4d12-8e79-e953128bf77f)
