### PR TITLE
CI: test with Node.js 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 22.x, 23.x]
+        node-version: [20.x, 22.x, 24.x]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
The security support for 23.x
ended 1 month and 1 week ago,
so replace it with 24.x.