### PR TITLE
Tame ESiInt in build scripts

### DIFF
--- a/buildprocess/configureWebpackForPlugins.js
+++ b/buildprocess/configureWebpackForPlugins.js
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+
 const path = require("path");
 const fs = require("fs");
 

--- a/buildprocess/webpack.config.js
+++ b/buildprocess/webpack.config.js
@@ -1,3 +1,6 @@
+/* eslint-disable no-undef */
+/* eslint-disable @typescript-eslint/no-require-imports */
+
 const configureWebpackForTerriaJS = require("terriajs/buildprocess/configureWebpack");
 const configureWebpackForPlugins = require("./configureWebpackForPlugins");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,6 +1,8 @@
 /*eslint-env node*/
 /*eslint no-sync: 0*/
 /*eslint no-process-exit: 0*/
+/*eslint no-redeclare: 0*/
+/*eslint @typescript-eslint/no-require-imports: 0*/
 
 "use strict";
 
@@ -229,6 +231,7 @@ gulp.task("sync-terriajs-dependencies", function (done) {
 
 function syncDependencies(dependencies, targetJson, justWarn) {
   for (var dependency in dependencies) {
+    // eslint-disable-next-line no-prototype-builtins
     if (dependencies.hasOwnProperty(dependency)) {
       var version =
         targetJson.dependencies[dependency] ||


### PR DESCRIPTION
When I open `gulpfile.js`, `buildprocess/webpack.config.js`, and `buildprocess/configureWebpackForPlugins.js` in my VS Code, I encounter numerous ESLint errors. 
My configuration is standard, so everyone should see the same.
Clearly, these files fall outside the scope of linting rules enforced for the source code.
I added annotations to stop ESLint from complaining about those lines.