### PR TITLE
Make it easy to deploy TerriaMap to GH Pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,61 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build
+        run: yarn gulp release --baseHref "/${{ github.event.repository.name }}/"
+        env:
+          NODE_OPTIONS: "--max_old_space_size=4096"
+
+      - name: Disable Jekyll
+        run: touch wwwroot/.nojekyll
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: wwwroot
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "version": "0.4.4",
   "description": "Geospatial catalog explorer based on TerriaJS.",
   "license": "Apache-2.0",
+  "packageManager": "yarn@1.22.22",
   "engines": {
     "node": ">= 20.0.0"
   },


### PR DESCRIPTION
We got a few notes from https://github.com/TerriaJS/TerriaMap/issues/773 about speedbumps when trying to deploy a TerriaMap to GitHub Pages.

This PR makes two changes to (hopefully) make this process a little more straightforward for future travelers. It:

1. Adds the `packageManager` field to `package.json` and pins `yarn@1.22.22` so that Corepack can manage it automatically.

1. Adds a GitHub Pages deployment workflow to this repo that uses Corepack (no npm dependency), our existing `--baseHref` gulp flag, and GitHub's official Pages deployment actions. Triggers on push to `main` (or manual dispatch).

Forks can enable GitHub Pages in their repo settings and this workflow will handle the rest.

Note: for this to work in this repo, we _also_ need to check our settings. We'd need:

- _Settings → Pages → Source_ -- set to "GitHub Actions" (not "Deploy from a branch")
- _Settings → Actions → General_ -- workflow permissions would need to allow Pages deployment
- [EDIT: ...and also enable GitHub Pages, if it isn't already enabled]

There may be Reasons some or all of this is not a good idea. Feedback welcome.