### PR TITLE
Require node 22 to match terriajs-server 5 alpha

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 - Upgrade terriajs-server to version 5 alpha
   - Requires node version 22 or above
+  - Bump Dockerfile base images and `engines.node` to node 22 to match this requirement
   - Comes with a new version of proxy rewritten using undici instead of deprecated `request` package. This should improve the performance and reliability of the proxy. Please test your map with this new version of terriajs-server and report any issues you find.
   - For full changelog see [terriajs-server CHANGES.md](https://github.com/TerriaJS/terriajs-server/blob/master/CHANGES.md#next-release---unreleased)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # develop container
-FROM node:20 AS develop
+FROM node:22 AS develop
 
 # build container
-FROM node:20 AS build
+FROM node:22 AS build
 USER node
 
 COPY --chown=node:node . /app
@@ -13,7 +13,7 @@ RUN yarn install --network-timeout 1000000
 RUN yarn gulp release
 
 # deploy container
-FROM node:20-slim AS deploy
+FROM node:22-slim AS deploy
 
 USER node
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "description": "Geospatial catalog explorer based on TerriaJS.",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">= 20.0.0"
+    "node": ">= 22.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Problem

The Dockerfile builds on `node:20`, but 
  `terriajs-server@5.0.0-alpha.2` (already pinned in `dependencies`) requires node `>=22`. A
  clean `docker build` therefore fails at `yarn install`:

```
[build 4/5] RUN yarn 
  install --network-timeout 1000000:
[1/5] Validating package.json...
[2/5] Resolving 
  packages...
[3/5] Fetching packages...
error terriajs-server@5.0.0-alpha.2: The engine 
  "node" is incompatible with this module. Expected version ">=22.0.0". Got "20.20.2"
error
  Found incompatible module.
ERROR: failed to build: process "/bin/sh -c yarn install 
  --network-timeout 1000000" did not complete successfully: exit code: 
  1
```

`engines.node` was also still `>= 20.0.0`, contradicting the existing 
  `CHANGES.md` note that 0.4.7 "Requires node version 22 or above".

## Fix

- Bump all 
  Dockerfile stages (`develop`, `build`, `deploy`) from `node:20`/`node:20-slim` to 
  `node:22`/`node:22-slim`
- Bump `engines.node` to `>= 22.0.0`
- Note the bump in 
  `CHANGES.md`

Verified: `docker build` now completes successfully end-to-end (`yarn 
  install` + `gulp release`) on node 22.